### PR TITLE
Adds support for automatic enum value binding.

### DIFF
--- a/src/Support/HandlesBoundValues.php
+++ b/src/Support/HandlesBoundValues.php
@@ -2,7 +2,6 @@
 
 namespace Javaabu\Forms\Support;
 
-use BackedEnum;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -84,11 +83,6 @@ trait HandlesBoundValues
 
         if ($bind instanceof Model && $boundValue instanceof DateTimeInterface) {
             return $this->formatDateTime($bind, $name, $boundValue);
-        }
-
-        // Handle automatic enum bindings
-        if ($bind instanceof Model && $boundValue instanceof BackedEnum) {
-            return $boundValue->value;
         }
 
         return $boundValue;

--- a/src/Support/HandlesBoundValues.php
+++ b/src/Support/HandlesBoundValues.php
@@ -2,6 +2,7 @@
 
 namespace Javaabu\Forms\Support;
 
+use BackedEnum;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -83,6 +84,11 @@ trait HandlesBoundValues
 
         if ($bind instanceof Model && $boundValue instanceof DateTimeInterface) {
             return $this->formatDateTime($bind, $name, $boundValue);
+        }
+
+        // Handle automatic enum bindings
+        if ($bind instanceof Model && $boundValue instanceof BackedEnum) {
+            return $boundValue->value;
         }
 
         return $boundValue;

--- a/src/Views/Components/Select.php
+++ b/src/Views/Components/Select.php
@@ -2,6 +2,7 @@
 
 namespace Javaabu\Forms\Views\Components;
 
+use BackedEnum;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -76,6 +77,10 @@ class Select extends Component
 
         if ($default instanceof Model) {
             $default = $idField ? $default->{$idField} : $default->getKey();
+        }
+
+        if ($default instanceof BackedEnum) {
+            $default = $default->value;
         }
 
         $this->selectedKey = old($inputName, $default);

--- a/tests/Feature/Models/Article.php
+++ b/tests/Feature/Models/Article.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Javaabu\Forms\Tests\Feature\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+enum ArticleStatuses: string {
+    case Draft = 'draft';
+    case Published = 'published';
+}
+
+class Article extends Model
+{
+    protected $fillable = [
+        'status',
+    ];
+
+    protected $casts = [
+        'status' => ArticleStatuses::class,
+    ];
+}

--- a/tests/Feature/Select2Test.php
+++ b/tests/Feature/Select2Test.php
@@ -3,10 +3,40 @@
 namespace Javaabu\Forms\Tests\Feature;
 
 use Illuminate\Support\Facades\Route;
+use Javaabu\Forms\Tests\Feature\Models\Article;
+use Javaabu\Forms\Tests\Feature\Models\ArticleStatuses;
 use Javaabu\Forms\Tests\TestCase;
 
 class Select2Test extends TestCase
 {
+    /** @test */
+    public function it_can_render_a_select_2_basic_element_whose_value_comes_from_an_enum_cast()
+    {
+        // create an article
+        $article = new Article([
+            'status' => ArticleStatuses::Draft,
+        ]);
+
+        // create options
+        $options = [
+            'draft' => 'Draft',
+            'published' => 'Published',
+        ];
+
+        Route::get('select2-enum', function () use ($article, $options) {
+            return view('select2-enum')
+                ->with('article', $article)
+                ->with('options', $options);
+        })->middleware('web');
+
+        $this->visit('/select2-enum')
+            ->seeElement('select.select2-basic[id="status"][data-allow-clear="true"][data-placeholder="Nothing Selected"]')
+            ->seeElement('option[value=""]')
+            ->seeElement('option[value="draft"]:selected')
+            ->seeElement('option[value="published"]');
+
+    }
+
     /** @test */
     public function it_can_render_a_select2_basic_element()
     {

--- a/tests/Feature/views/select2-enum.blade.php
+++ b/tests/Feature/views/select2-enum.blade.php
@@ -1,0 +1,4 @@
+<x-forms::form :model="$article">
+    <x-forms::select2 name="status" :options="$options" />
+    <x-forms::submit>Submit</x-forms::submit>
+</x-forms::form>


### PR DESCRIPTION
Currently, a column with a cast of an Enum does not automatically mark the correct option as selected when used in a Select2 component. 

This PR adds in support for this. A test has been created for this and passes. 